### PR TITLE
feat: predeclared functions support for ECE and `println`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "**/gl": "^6.0.2"
   },
   "scripts": {
-    "build": "yarn docs && tsc --build --force",
+    "build": "yarn docs && yarn build:slang",
     "build:go": "peggy src/go-slang/parser/*.pegjs",
     "build:slang": "yarn build:go && tsc --build --force",
     "eslint": "eslint --ext \".ts,.tsx\" src",

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -647,7 +647,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
   if (context.chapter === Chapter.GO_1) {
     // NOTE: we are using this purely for the purpose of console capturing
-    // that `rawDisplay` provides. `raw_display` will NOT be a predeclared 
+    // that `rawDisplay` provides. `raw_display` will NOT be a predeclared
     // function in the Go ECE runtime.
     // We are defining as a slang builtin here so that the Go ECE runtime
     // can get a reference to it via `context.nativeStorage.builtins` map.

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -644,6 +644,15 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       }
     }
   }
+
+  if (context.chapter === Chapter.GO_1) {
+    // NOTE: we are using this purely for the purpose of console capturing
+    // that `rawDisplay` provides. `raw_display` will NOT be a predeclared 
+    // function in the Go ECE runtime.
+    // We are defining as a slang builtin here so that the Go ECE runtime
+    // can get a reference to it via `context.nativeStorage.builtins` map.
+    defineBuiltin(context, 'slangRawDisplay(str, prepend = undefined)', rawDisplay, 1)
+  }
 }
 
 function importPrelude(context: Context) {

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -107,8 +107,7 @@ export function evaluate(program: SourceFile, slangContext: SlangContext): Value
     Context.E = result.value as Environment
   }
 
-  // return the top of the stash
-  return S.pop()
+  return 'Program exited'
 }
 
 const interpreter: {

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -1,10 +1,11 @@
-import { Context } from '..'
+import { Context as SlangContext } from '..'
 import { Stack } from '../cse-machine/utils'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Value } from '../types'
 import { FuncArityError, UndefinedError, UnknownInstructionError } from './error'
 import { evaluateBinaryOp } from './lib/binaryOp'
 import { Environment, createGlobalEnvironment } from './lib/env'
+import { PREDECLARED_FUNCTIONS } from './lib/predeclared'
 import { zip } from './lib/utils'
 import {
   AssignOp,
@@ -24,6 +25,7 @@ import {
   Instruction,
   Literal,
   NodeType,
+  PopS,
   SourceFile,
   UnaryExpression,
   UnaryOp,
@@ -33,6 +35,14 @@ import {
 
 type Control = Stack<Instruction>
 type Stash = Stack<any>
+type Builtins = Map<number, (...args: any[]) => any>
+
+interface Context {
+  C: Control
+  S: Stash
+  E: Environment
+  B: Builtins
+}
 
 // IResult is a type that represents the result of an interpreter operation
 class IResult<T, E extends RuntimeSourceError> {
@@ -57,10 +67,26 @@ const CALL_MAIN: CallExpression = {
   args: []
 }
 
-export function evaluate(program: SourceFile, context: Context): Value {
+export function evaluate(program: SourceFile, slangContext: SlangContext): Value {
   const C = new Stack<Instruction>()
   const S = new Stack<any>()
-  let E = createGlobalEnvironment()
+  const E = createGlobalEnvironment()
+
+  // inject predeclared functions into the global environment
+  const B = new Map<number, (...args: any[]) => any>()
+  PREDECLARED_FUNCTIONS.forEach(({ name, func, op }, id) => {
+    E.declare(name, { ...op, id })
+    if (name === 'println') {
+      // println is special case where we need to the `rawDisplay` slang builtin for
+      // console capture, therefore we handle it differently from other predeclared functions
+      // NOTE: we assume that the `rawDisplay` builtin always exists
+      B.set(id, func(slangContext.nativeStorage.builtins.get('slangRawDisplay')))
+      return
+    }
+    B.set(id, func)
+  })
+
+  const Context = { C, S, E, B }
 
   // start the program by calling `main`
   C.pushR(program, CALL_MAIN)
@@ -69,16 +95,16 @@ export function evaluate(program: SourceFile, context: Context): Value {
     const inst = C.pop() as Instruction
 
     if (!interpreter.hasOwnProperty(inst.type)) {
-      context.errors.push(new UnknownInstructionError(inst.type))
+      slangContext.errors.push(new UnknownInstructionError(inst.type))
       return undefined
     }
 
-    const result = interpreter[inst.type](inst, C, S, E) ?? IResult.ok(E)
+    const result = interpreter[inst.type](inst, Context) ?? IResult.ok(Context.E)
     if (!result.ok) {
-      context.errors.push(result.error as RuntimeSourceError)
+      slangContext.errors.push(result.error as RuntimeSourceError)
       return undefined
     }
-    E = result.value as Environment
+    Context.E = result.value as Environment
   }
 
   // return the top of the stash
@@ -88,14 +114,12 @@ export function evaluate(program: SourceFile, context: Context): Value {
 const interpreter: {
   [key: string]: (
     inst: Instruction,
-    C: Control,
-    S: Stash,
-    E: Environment
+    context: Context
   ) => IResult<Environment, RuntimeSourceError> | void
 } = {
-  SourceFile: ({ topLevelDecls }: SourceFile, C, _S, _E) => C.pushR(...topLevelDecls),
+  SourceFile: ({ topLevelDecls }: SourceFile, { C }) => C.pushR(...topLevelDecls),
 
-  FunctionDeclaration: ({ name: id, params, body }: FunctionDeclaration, C, _S, _E) =>
+  FunctionDeclaration: ({ name: id, params, body }: FunctionDeclaration, { C }) =>
     C.push({
       type: CommandType.FuncDeclOp,
       name: id.name,
@@ -103,12 +127,12 @@ const interpreter: {
       body: body
     }),
 
-  Block: ({ statements }: Block, C, _S, E) => {
+  Block: ({ statements }: Block, { C, E }) => {
     C.pushR(...statements, { type: CommandType.EnvOp, env: E })
     return IResult.ok(E.extend({}))
   },
 
-  VariableDeclaration: ({ left, right }: VariableDeclaration, C, _S, _E) => {
+  VariableDeclaration: ({ left, right }: VariableDeclaration, { C }) => {
     if (right.length === 0) {
       // if there are no right-hand side expressions, we declare zero values
       const zvDecls = left.map(({ name }) => ({
@@ -125,16 +149,16 @@ const interpreter: {
     )
   },
 
-  Assignment: ({ left, right }: Assignment, C, _S, _E) =>
+  Assignment: ({ left, right }: Assignment, { C }) =>
     zip(left, right).forEach(([leftExpr, rightExpr]) => {
       if (leftExpr.type === NodeType.Identifier) {
         C.pushR(rightExpr, { type: CommandType.AssignOp, name: leftExpr.name })
       }
     }),
 
-  Literal: (inst: Literal, _C, S, _E) => S.push(inst.value),
+  Literal: (inst: Literal, { S }) => S.push(inst.value),
 
-  Identifier: ({ name }: Identifier, _C, S, E) => {
+  Identifier: ({ name }: Identifier, { S, E }) => {
     const value = E.lookup(name)
     if (value === null) {
       return IResult.error(new UndefinedError(name))
@@ -143,46 +167,45 @@ const interpreter: {
     return
   },
 
-  UnaryExpression: ({ argument, operator }: UnaryExpression, C, _S, _E) =>
+  UnaryExpression: ({ argument, operator }: UnaryExpression, { C }) =>
     C.pushR(argument, { type: CommandType.UnaryOp, operator }),
 
-  UnaryOp: ({ operator }: UnaryOp, _C, S, _E) => {
+  UnaryOp: ({ operator }: UnaryOp, { S }) => {
     const operand = S.pop()
     S.push(operator === '-' ? -operand : operand)
   },
 
-  BinaryExpression: ({ left, right, operator }: BinaryExpression, C, _S, _E) =>
+  BinaryExpression: ({ left, right, operator }: BinaryExpression, { C }) =>
     C.pushR(left, right, { type: CommandType.BinaryOp, operator: operator }),
 
-  CallExpression: ({ callee, args }: CallExpression, C, _S, _E) =>
+  CallExpression: ({ callee, args }: CallExpression, { C }) =>
     C.pushR(callee, ...args, {
       type: CommandType.CallOp,
       calleeName: callee.name,
       arity: args.length
     }),
 
-  ExpressionStatement: ({ expression }: ExpressionStatement, C, _S, _E) =>
-    C.pushR(expression, { type: CommandType.PopSOp }),
+  ExpressionStatement: ({ expression }: ExpressionStatement, { C }) => C.pushR(expression, PopS),
 
-  FuncDeclOp: ({ name, params, body }: FuncDeclOp, _C, _S, E) =>
+  FuncDeclOp: ({ name, params, body }: FuncDeclOp, { E }) =>
     E.declare(name, { type: CommandType.ClosureOp, params, body, env: E }),
 
-  VarDeclOp: ({ name, zeroValue }: VarDeclOp, _C, S, E) =>
+  VarDeclOp: ({ name, zeroValue }: VarDeclOp, { S, E }) =>
     zeroValue ? E.declareZeroValue(name) : E.declare(name, S.pop()),
 
-  AssignOp: ({ name }: AssignOp, _C, S, E) => {
+  AssignOp: ({ name }: AssignOp, { S, E }) => {
     if (!E.assign(name, S.pop())) {
       return IResult.error(new UndefinedError(name))
     }
     return
   },
 
-  BinaryOp: ({ operator }: BinaryOp, _C, S, _E) => {
+  BinaryOp: ({ operator }: BinaryOp, { S }) => {
     const [left, right] = S.popNR(2)
     S.push(evaluateBinaryOp(operator, left, right))
   },
 
-  CallOp: ({ calleeName, arity }: CallOp, C, S, E) => {
+  CallOp: ({ calleeName, arity }: CallOp, { C, S, E }) => {
     const values = S.popNR(arity)
     const { params, body: callee } = S.pop() as ClosureOp
 
@@ -194,7 +217,7 @@ const interpreter: {
     return IResult.ok(E.extend(Object.entries(zip(params, values))))
   },
 
-  EnvOp: ({ env }: EnvOp, _C, _S, _E) => IResult.ok(env),
+  EnvOp: ({ env }: EnvOp) => IResult.ok(env),
 
-  PopSOp: (_inst, _C, S, _E) => { S.pop() } // prettier-ignore
+  PopSOp: (_inst, {S}) => { S.pop() } // prettier-ignore
 }

--- a/src/go-slang/lib/env.ts
+++ b/src/go-slang/lib/env.ts
@@ -1,3 +1,5 @@
+import { PREDECLARED_IDENTIFIERS } from './predeclared'
+
 type Maybe<T> = T | null
 
 export class Environment {
@@ -36,11 +38,6 @@ export class Environment {
   public extend(bindings: { [key: string]: any }): Environment {
     return new Environment(bindings, this)
   }
-}
-
-const PREDECLARED_IDENTIFIERS = {
-  true: true,
-  false: false
 }
 
 export function createGlobalEnvironment(): Environment {

--- a/src/go-slang/lib/predeclared.ts
+++ b/src/go-slang/lib/predeclared.ts
@@ -1,0 +1,38 @@
+import { BuiltinOp, CommandType } from '../types'
+
+export interface PredeclaredFunc {
+  name: string
+  func: (...args: any) => any
+  op: Omit<BuiltinOp, 'id'>
+}
+
+export const PREDECLARED_IDENTIFIERS: { [key: string]: any } = {
+  true: true,
+  false: false
+}
+
+/**
+ * println is a predeclared function in Go that prints values to stdout.
+ *
+ * println wraps around the rawDisplay function that contains the console capture.
+ * Since there is no way to directly output to frontend, we have to make sure of slang's native
+ * rawDisplay function to capture the output and display it in the frontend.
+ *
+ * @param slangRawDisplay rawDisplay function that contains the console capture
+ * @returns a function that takes any number of arguments and prints them to the console
+ */
+function println(slangRawDisplay: (str: string) => void): (...args: any) => void {
+  return (...args: any) =>
+    slangRawDisplay(args.map((arg: { toString: () => any }) => arg.toString()).join(' '))
+}
+
+export const PREDECLARED_FUNCTIONS: PredeclaredFunc[] = [
+  {
+    name: 'println',
+    func: println,
+    op: {
+      type: CommandType.BuiltinOp,
+      arity: undefined
+    }
+  }
+]

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -121,7 +121,9 @@ export enum CommandType {
   BinaryOp = 'BinaryOp',
   CallOp = 'CallOp',
   EnvOp = 'EnvOp',
-  PopSOp = 'PopSOp'
+  PopSOp = 'PopSOp',
+  BuiltinOp = 'BuiltinOp',
+  ApplyBuiltinOp = 'ApplyBuiltinOp'
 }
 
 export interface Command {
@@ -141,6 +143,18 @@ export interface ClosureOp extends Command {
   params: string[]
   body: Block
   env: Environment
+}
+
+export interface BuiltinOp extends Command {
+  type: CommandType.BuiltinOp
+  id: number
+  arity?: number
+}
+
+export interface ApplyBuiltinOp extends Command {
+  type: CommandType.ApplyBuiltinOp
+  builtinOp: BuiltinOp
+  values: any[]
 }
 
 export interface VarDeclOp extends Command {
@@ -188,6 +202,8 @@ export type Instruction =
   | Expression
   | FuncDeclOp
   | ClosureOp
+  | BuiltinOp
+  | ApplyBuiltinOp
   | VarDeclOp
   | AssignOp
   | UnaryOp


### PR DESCRIPTION
# Description

This PR implements ECE support for predeclared function (or "builtin" functions). The main goal of having predeclared function support is for `println` so that we get to inspect intermediate results when testing out the ECE.

`println` works now but it is a hack. The main issue comes from the fact that we are unable to capture the console in `go-slang` directly, and because I didn't want to revamp the entire frontend console capture system made for `slang`, I just jerry-rigged the `rawDisplay` function (with console capturing) and wrapped it in the implementation of `println`:

https://github.com/shenyih0ng/go-slang/blob/934d559b608fb255995ae6b888f2edaff25bed24/src/go-slang/lib/predeclared.ts#L14-L27

With that, we can now `println` 🎉

<img width="1112" alt="image" src="https://github.com/shenyih0ng/go-slang/assets/47914880/cc6aa687-8137-47e6-b86f-e72ad5ce7472">
