### PR TITLE
feat: return statements

### DIFF
--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -136,8 +136,8 @@ const interpreter: {
     return IResult.ok(E.extend({}))
   },
 
-  ReturnStatement: ({ expressions }: ReturnStatement, { C }) =>
-    C.pushR(...expressions, { type: CommandType.PopTillMOp, marker: RetMarker }),
+  ReturnStatement: ({ expression }: ReturnStatement, { C }) =>
+    C.pushR(expression, { type: CommandType.PopTillMOp, marker: RetMarker }),
 
   VariableDeclaration: ({ left, right }: VariableDeclaration, { C }) => {
     if (right.length === 0) {

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -28,6 +28,9 @@ import {
   Literal,
   NodeType,
   PopS,
+  PopTillMOp,
+  RetMarker,
+  ReturnStatement,
   SourceFile,
   UnaryExpression,
   UnaryOp,
@@ -133,6 +136,9 @@ const interpreter: {
     return IResult.ok(E.extend({}))
   },
 
+  ReturnStatement: ({ expressions }: ReturnStatement, { C }) =>
+    C.pushR(...expressions, { type: CommandType.PopTillMOp, marker: RetMarker }),
+
   VariableDeclaration: ({ left, right }: VariableDeclaration, { C }) => {
     if (right.length === 0) {
       // if there are no right-hand side expressions, we declare zero values
@@ -171,11 +177,6 @@ const interpreter: {
   UnaryExpression: ({ argument, operator }: UnaryExpression, { C }) =>
     C.pushR(argument, { type: CommandType.UnaryOp, operator }),
 
-  UnaryOp: ({ operator }: UnaryOp, { S }) => {
-    const operand = S.pop()
-    S.push(operator === '-' ? -operand : operand)
-  },
-
   BinaryExpression: ({ left, right, operator }: BinaryExpression, { C }) =>
     C.pushR(left, right, { type: CommandType.BinaryOp, operator: operator }),
 
@@ -201,6 +202,11 @@ const interpreter: {
     return
   },
 
+  UnaryOp: ({ operator }: UnaryOp, { S }) => {
+    const operand = S.pop()
+    S.push(operator === '-' ? -operand : operand)
+  },
+
   BinaryOp: ({ operator }: BinaryOp, { S }) => {
     const [left, right] = S.popNR(2)
     S.push(evaluateBinaryOp(operator, left, right))
@@ -221,7 +227,7 @@ const interpreter: {
       return IResult.error(new FuncArityError(calleeName, values.length, params.length))
     }
 
-    C.pushR(callee, { type: CommandType.EnvOp, env: E })
+    C.pushR(callee, RetMarker, { type: CommandType.EnvOp, env: E })
     return IResult.ok(E.extend(Object.entries(zip(params, values))))
   },
 
@@ -230,5 +236,11 @@ const interpreter: {
 
   EnvOp: ({ env }: EnvOp) => IResult.ok(env),
 
-  PopSOp: (_inst, { S }) => void S.pop()
+  PopSOp: (_inst, { S }) => void S.pop(),
+
+  PopTillMOp: ({ marker }: PopTillMOp, { C }) => {
+    while (!C.isEmpty() && C.pop() !== marker) {}
+  },
+
+  RetMarker: () => void {}
 }

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -228,7 +228,7 @@ const interpreter: {
     }
 
     C.pushR(callee, RetMarker, { type: CommandType.EnvOp, env: E })
-    return IResult.ok(E.extend(Object.entries(zip(params, values))))
+    return IResult.ok(E.extend(Object.fromEntries(zip(params, values))))
   },
 
   ApplyBuiltinOp: ({ builtinOp: { id }, values }: ApplyBuiltinOp, { B }) =>

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -399,11 +399,14 @@ function peg$parse(input, options) {
   var peg$f19 = function(statements) {
         return { type: "Block", statements }
       };
-  var peg$f20 = function(left, right) {
+  var peg$f20 = function(expressions) {
+        return { type: "ReturnStatement", expressions }
+      };
+  var peg$f21 = function(left, right) {
         return { type: "Assignment", left, right }
       };
-  var peg$f21 = function(head, tail) { return buildList(head, tail, 3); };
   var peg$f22 = function(head, tail) { return buildList(head, tail, 3); };
+  var peg$f23 = function(head, tail) { return buildList(head, tail, 3); };
   var peg$currPos = options.peg$currPos | 0;
   var peg$savedPos = peg$currPos;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -601,7 +604,10 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseSimpleStatement();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseBlock();
+        s0 = peg$parseReturnStatement();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseBlock();
+        }
       }
     }
 
@@ -1700,6 +1706,30 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseReturnStatement() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRETURN_TOKEN();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      s3 = peg$parseExpressionList();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parseEOS();
+        peg$savedPos = s0;
+        s0 = peg$f20(s3);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5, s6;
 
@@ -1720,7 +1750,7 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parseEOS();
           peg$savedPos = s0;
-          s0 = peg$f20(s1, s5);
+          s0 = peg$f21(s1, s5);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1795,7 +1825,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f21(s1, s3);
+      s0 = peg$f22(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1862,7 +1892,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f22(s1, s3);
+      s0 = peg$f23(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -399,8 +399,8 @@ function peg$parse(input, options) {
   var peg$f19 = function(statements) {
         return { type: "Block", statements }
       };
-  var peg$f20 = function(expressions) {
-        return { type: "ReturnStatement", expressions }
+  var peg$f20 = function(expression) {
+        return { type: "ReturnStatement", expression }
       };
   var peg$f21 = function(left, right) {
         return { type: "Assignment", left, right }
@@ -1713,7 +1713,7 @@ function peg$parse(input, options) {
     s1 = peg$parseRETURN_TOKEN();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
-      s3 = peg$parseExpressionList();
+      s3 = peg$parseExpression();
       if (s3 !== peg$FAILED) {
         s4 = peg$parseEOS();
         peg$savedPos = s0;

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -43,6 +43,7 @@ TopLevelDeclaration
 Statement
     = Declaration
     / SimpleStatement
+    / ReturnStatement
     / Block
 
 Declaration
@@ -206,6 +207,13 @@ Signature
 Block "block"
     = "{" _ statements:Statement* _ "}" EOS {
         return { type: "Block", statements }
+      }
+
+/* Return Statement */
+
+ReturnStatement
+    = RETURN_TOKEN _ expressions:ExpressionList EOS {
+        return { type: "ReturnStatement", expressions }
       }
 
 /* Assignment */

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -212,8 +212,8 @@ Block "block"
 /* Return Statement */
 
 ReturnStatement
-    = RETURN_TOKEN _ expressions:ExpressionList EOS {
-        return { type: "ReturnStatement", expressions }
+    = RETURN_TOKEN _ expression:Expression EOS {
+        return { type: "ReturnStatement", expression }
       }
 
 /* Assignment */

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -128,6 +128,7 @@ export enum CommandType {
   CallOp = 'CallOp',
   EnvOp = 'EnvOp',
   PopSOp = 'PopSOp',
+  PopTillMOp = 'PopTillMOp',
   BuiltinOp = 'BuiltinOp',
   ApplyBuiltinOp = 'ApplyBuiltinOp'
 }
@@ -199,6 +200,23 @@ export interface PopSOp extends Command {
   type: CommandType.PopSOp
 }
 
+export const PopS: PopSOp = { type: CommandType.PopSOp }
+
+export interface PopTillMOp extends Command {
+  type: CommandType.PopTillMOp
+  marker: Marker
+}
+
+export enum MarkerType {
+  RetMarker = 'RetMarker'
+}
+
+export interface Marker {
+  type: MarkerType
+}
+
+export const RetMarker = { type: MarkerType.RetMarker }
+
 export type Instruction =
   | SourceFile
   | VariableDeclaration
@@ -218,5 +236,5 @@ export type Instruction =
   | CallOp
   | EnvOp
   | PopSOp
-
-export const PopS: PopSOp = { type: CommandType.PopSOp }
+  | PopTillMOp
+  | Marker

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -5,6 +5,7 @@ export enum NodeType {
   Block = 'Block',
   VariableDeclaration = 'VariableDeclaration',
   FunctionDeclaration = 'FunctionDeclaration',
+  ReturnStatement = 'ReturnStatement',
   ExpressionStatement = 'ExpressionStatement',
   Assignment = 'Assignment',
   UnaryExpression = 'UnaryExpression',
@@ -18,7 +19,7 @@ type TopLevelDeclaration = Declaration | FunctionDeclaration
 
 type Declaration = VariableDeclaration
 
-type Statement = Declaration | Block
+type Statement = Declaration | ReturnStatement | Block
 
 type Expression =
   | Identifier
@@ -48,6 +49,11 @@ export interface FunctionDeclaration extends Node {
   name: Identifier
   params: Identifier[]
   body: Block
+}
+
+export interface ReturnStatement extends Node {
+  type: NodeType.ReturnStatement
+  expressions: Expression[]
 }
 
 export interface Block extends Node {
@@ -199,6 +205,7 @@ export type Instruction =
   | FunctionDeclaration
   | Block
   | ExpressionStatement
+  | ReturnStatement
   | Expression
   | FuncDeclOp
   | ClosureOp

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -53,7 +53,7 @@ export interface FunctionDeclaration extends Node {
 
 export interface ReturnStatement extends Node {
   type: NodeType.ReturnStatement
-  expressions: Expression[]
+  expression: Expression
 }
 
 export interface Block extends Node {


### PR DESCRIPTION
# Description

This PR implements support for `ReturnStmts` in the Go ECE. However, note that this does not give support for multi expression return values i.e. `return 1,2,3` yet. 

Multi-expression return values will probably require us to implement constructs like tuples and tuple de-structuring if we want to support declarations like `a, b, c := return_three_values()`. This seems a like a non-essential feature right now so  I've restricted the grammar to only accept single expression returns.

With that, we can now do:

<img width="1024" alt="image" src="https://github.com/shenyih0ng/go-slang/assets/47914880/63e003c7-0dbe-4995-b84b-c8cc051b4ad4">
