### PR TITLE
feat: for statement

### DIFF
--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -156,25 +156,23 @@ const interpreter: {
 
   ForStatement: (inst: ForStatement, { C }) => {
     const { form, block } = inst
-    switch (form.type) {
-      case ForFormType.ForCondition:
-        const branch = { type: CommandType.BranchOp, cons: block, alt: PopTillM(ForEndMarker) }
-        C.pushR(form.expression, branch as BranchOp, ForStartMarker, inst, ForEndMarker)
-        break
-      case ForFormType.ForClause:
-        const { init, cond, post } = form
-        const forBlock: Block = {
-          type: NodeType.Block,
-          statements: [
-            init ?? EmptyStmt,
-            {
-              type: NodeType.ForStatement,
-              form: { type: ForFormType.ForCondition, expression: cond ?? True },
-              block: { type: NodeType.Block, statements: [block, ForPostMarker, post ?? EmptyStmt] }
-            }
-          ]
-        }
-        C.push(forBlock)
+    if (form === null || form.type === ForFormType.ForCondition) {
+      const branch = { type: CommandType.BranchOp, cons: block, alt: PopTillM(ForEndMarker) }
+      C.pushR(form ? form.expression : True, branch as BranchOp, ForStartMarker, inst, ForEndMarker)
+    } else if (form.type === ForFormType.ForClause) {
+      const { init, cond, post } = form
+      const forBlock: Block = {
+        type: NodeType.Block,
+        statements: [
+          init ?? EmptyStmt,
+          {
+            type: NodeType.ForStatement,
+            form: { type: ForFormType.ForCondition, expression: cond ?? True },
+            block: { type: NodeType.Block, statements: [block, ForPostMarker, post ?? EmptyStmt] }
+          }
+        ]
+      }
+      C.push(forBlock)
     }
   },
 

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -6,7 +6,7 @@ import { FuncArityError, UndefinedError, UnknownInstructionError } from './error
 import { evaluateBinaryOp } from './lib/binaryOp'
 import { Environment, createGlobalEnvironment } from './lib/env'
 import { PREDECLARED_FUNCTIONS } from './lib/predeclared'
-import { zip } from './lib/utils'
+import { zip, isAny } from './lib/utils'
 import {
   ApplyBuiltinOp,
   AssignOp,
@@ -272,8 +272,8 @@ const interpreter: {
 
   PopSOp: (_inst, { S }) => void S.pop(),
 
-  PopTillMOp: ({ marker }: PopTillMOp, { C }) => {
-    while (!C.isEmpty() && C.pop() !== marker) {}
+  PopTillMOp: ({ markers }: PopTillMOp, { C }) => {
+    while (!C.isEmpty() && !isAny(C.pop(), markers)) {}
   },
 
   RetMarker: () => void {},

--- a/src/go-slang/ece.ts
+++ b/src/go-slang/ece.ts
@@ -161,18 +161,23 @@ const interpreter: {
       C.pushR(form ? form.expression : True, branch as BranchOp, ForStartMarker, inst, ForEndMarker)
     } else if (form.type === ForFormType.ForClause) {
       const { init, cond, post } = form
-      const forBlock: Block = {
+      C.push({
         type: NodeType.Block,
         statements: [
           init ?? EmptyStmt,
           {
             type: NodeType.ForStatement,
             form: { type: ForFormType.ForCondition, expression: cond ?? True },
-            block: { type: NodeType.Block, statements: [block, ForPostMarker, post ?? EmptyStmt] }
+            block: {
+              type: NodeType.Block,
+              statements: [
+                { ...block, statements: block.statements.concat(ForPostMarker) },
+                post ?? EmptyStmt
+              ]
+            }
           }
         ]
-      }
-      C.push(forBlock)
+      })
     }
   },
 

--- a/src/go-slang/lib/utils.ts
+++ b/src/go-slang/lib/utils.ts
@@ -8,3 +8,7 @@ export function zip<T1, T2>(first: Array<T1>, second: Array<T2>): Array<[T1, T2]
 
   return zipped
 }
+
+export function isAny<T1, T2>(query: T1, values: T2[]): boolean {
+  return query ? values.some(v => v === query) : false
+}

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -419,11 +419,16 @@ function peg$parse(input, options) {
       };
   var peg$f22 = function(stmt) { return stmt };
   var peg$f23 = function(alt) { return alt };
-  var peg$f24 = function(left, right) {
+  var peg$f24 = function(form, block) { return { type: "ForStatement", form, block} };
+  var peg$f25 = function(expression) { return { type: "ForCondition", expression } };
+  var peg$f26 = function(init, cond, post) {
+        return { type: "ForClause", init, cond, post }
+      };
+  var peg$f27 = function(left, right) {
         return { type: "Assignment", left, right }
       };
-  var peg$f25 = function(head, tail) { return buildList(head, tail, 3); };
-  var peg$f26 = function(head, tail) { return buildList(head, tail, 3); };
+  var peg$f28 = function(head, tail) { return buildList(head, tail, 3); };
+  var peg$f29 = function(head, tail) { return buildList(head, tail, 3); };
   var peg$currPos = options.peg$currPos | 0;
   var peg$savedPos = peg$currPos;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -626,7 +631,10 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$parseIfStatement();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseBlock();
+            s0 = peg$parseForStatement();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseBlock();
+            }
           }
         }
       }
@@ -1827,6 +1835,110 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseForStatement() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFOR_TOKEN();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      s3 = peg$parseForForm();
+      if (s3 === peg$FAILED) {
+        s3 = null;
+      }
+      s4 = peg$parse__();
+      s5 = peg$parseBlock();
+      if (s5 !== peg$FAILED) {
+        s6 = peg$parseEOS();
+        peg$savedPos = s0;
+        s0 = peg$f24(s3, s5);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseForForm() {
+    var s0;
+
+    s0 = peg$parseForClause();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseForCondition();
+    }
+
+    return s0;
+  }
+
+  function peg$parseForCondition() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRelationalExpression();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f25(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseForClause() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSimpleStatement();
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    s2 = peg$parse__();
+    if (input.charCodeAt(peg$currPos) === 59) {
+      s3 = peg$c17;
+      peg$currPos++;
+    } else {
+      s3 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e34); }
+    }
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse__();
+      s5 = peg$parseRelationalExpression();
+      if (s5 === peg$FAILED) {
+        s5 = null;
+      }
+      s6 = peg$parse__();
+      if (input.charCodeAt(peg$currPos) === 59) {
+        s7 = peg$c17;
+        peg$currPos++;
+      } else {
+        s7 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
+      }
+      if (s7 !== peg$FAILED) {
+        s8 = peg$parse__();
+        s9 = peg$parseSimpleStatement();
+        if (s9 === peg$FAILED) {
+          s9 = null;
+        }
+        peg$savedPos = s0;
+        s0 = peg$f26(s1, s5, s9);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5, s6;
 
@@ -1847,7 +1959,7 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parseEOS();
           peg$savedPos = s0;
-          s0 = peg$f24(s1, s5);
+          s0 = peg$f27(s1, s5);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1922,7 +2034,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f25(s1, s3);
+      s0 = peg$f28(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1989,7 +2101,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f26(s1, s3);
+      s0 = peg$f29(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -424,11 +424,13 @@ function peg$parse(input, options) {
   var peg$f26 = function(init, cond, post) {
         return { type: "ForClause", init, cond, post }
       };
-  var peg$f27 = function(left, right) {
+  var peg$f27 = function() { return { type: "BreakStatement" } };
+  var peg$f28 = function() { return { type: "ContinueStatement" } };
+  var peg$f29 = function(left, right) {
         return { type: "Assignment", left, right }
       };
-  var peg$f28 = function(head, tail) { return buildList(head, tail, 3); };
-  var peg$f29 = function(head, tail) { return buildList(head, tail, 3); };
+  var peg$f30 = function(head, tail) { return buildList(head, tail, 3); };
+  var peg$f31 = function(head, tail) { return buildList(head, tail, 3); };
   var peg$currPos = options.peg$currPos | 0;
   var peg$savedPos = peg$currPos;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -633,7 +635,13 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$parseForStatement();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseBlock();
+              s0 = peg$parseBreakStatement();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseContinueStatement();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseBlock();
+                }
+              }
             }
           }
         }
@@ -1939,6 +1947,40 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseBreakStatement() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$parseBREAK_TOKEN();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseEOS();
+      peg$savedPos = s0;
+      s0 = peg$f27();
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseContinueStatement() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$parseCONTINUE_TOKEN();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseEOS();
+      peg$savedPos = s0;
+      s0 = peg$f28();
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5, s6;
 
@@ -1959,7 +2001,7 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parseEOS();
           peg$savedPos = s0;
-          s0 = peg$f27(s1, s5);
+          s0 = peg$f29(s1, s5);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2034,7 +2076,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f28(s1, s3);
+      s0 = peg$f30(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2101,7 +2143,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f29(s1, s3);
+      s0 = peg$f31(s1, s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -45,6 +45,7 @@ Statement
     / SimpleStatement
     / ReturnStatement
     / IfStatement
+    / ForStatement
     / Block
 
 Declaration
@@ -229,6 +230,23 @@ IfSimpleStatement
 
 ElseBranch
 	= ELSE_TOKEN _ alt:(Block / (IfStatement)) { return alt }
+
+/* For Statement */
+
+ForStatement
+    = FOR_TOKEN __ form:ForForm? __ block:Block EOS { return { type: "ForStatement", form, block} }
+      
+ForForm
+	= ForClause
+    / ForCondition
+
+ForCondition
+	= expression:Expression { return { type: "ForCondition", expression } }
+
+ForClause
+    = init:SimpleStatement? __ ";" __ cond:Expression? __ ";" __ post:SimpleStatement? {
+        return { type: "ForClause", init, cond, post }
+      }
 
 /* Assignment */
 

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -46,6 +46,8 @@ Statement
     / ReturnStatement
     / IfStatement
     / ForStatement
+    / BreakStatement
+    / ContinueStatement
     / Block
 
 Declaration
@@ -247,6 +249,16 @@ ForClause
     = init:SimpleStatement? __ ";" __ cond:Expression? __ ";" __ post:SimpleStatement? {
         return { type: "ForClause", init, cond, post }
       }
+
+/* Break Statement */
+
+BreakStatement
+    = BREAK_TOKEN EOS { return { type: "BreakStatement" } }
+
+/* Continue Statement */
+
+ContinueStatement
+    = CONTINUE_TOKEN EOS { return { type: "ContinueStatement" } }
 
 /* Assignment */
 

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -7,6 +7,7 @@ export enum NodeType {
   FunctionDeclaration = 'FunctionDeclaration',
   ReturnStatement = 'ReturnStatement',
   IfStatement = 'IfStatement',
+  ForStatement = 'ForStatement',
   ExpressionStatement = 'ExpressionStatement',
   Assignment = 'Assignment',
   UnaryExpression = 'UnaryExpression',
@@ -20,7 +21,7 @@ type TopLevelDeclaration = Declaration | FunctionDeclaration
 
 type Declaration = VariableDeclaration
 
-type Statement = Declaration | ReturnStatement | IfStatement | Block
+type Statement = Declaration | ReturnStatement | IfStatement | ForStatement | Block
 
 type SimpleStatement = ExpressionStatement | Assignment | Declaration
 
@@ -65,6 +66,31 @@ export interface IfStatement extends Node {
   cond: Expression
   cons: Block
   alt: IfStatement | Block | null
+}
+
+type ForForm = ForCondition | ForClause
+
+export enum ForFormType {
+  ForCondition = 'ForCondition',
+  ForClause = 'ForClause'
+}
+
+export interface ForStatement extends Node {
+  type: NodeType.ForStatement
+  form: ForForm
+  block: Block
+}
+
+export interface ForCondition {
+  type: ForFormType.ForCondition
+  expression: Expression
+}
+
+export interface ForClause {
+  type: ForFormType.ForClause
+  init: SimpleStatement | null
+  cond: Expression | null
+  post: SimpleStatement | null
 }
 
 export interface Block extends Node {
@@ -194,7 +220,8 @@ export interface CallOp extends Command {
 export interface BranchOp extends Command {
   type: CommandType.BranchOp
   cons: Block
-  alt: IfStatement | Block | null
+  // TEMP: need to rethink if adding PopTillMOp is a good idea
+  alt: IfStatement | Block | PopTillMOp | null
 }
 
 export interface EnvOp extends Command {
@@ -213,6 +240,8 @@ export interface PopTillMOp extends Command {
   marker: Marker
 }
 
+export const PopTillM = (marker: Marker): PopTillMOp => ({ type: CommandType.PopTillMOp, marker })
+
 export interface BuiltinOp extends Command {
   type: CommandType.BuiltinOp
   id: number
@@ -226,7 +255,8 @@ export interface ApplyBuiltinOp extends Command {
 }
 
 export enum MarkerType {
-  RetMarker = 'RetMarker'
+  RetMarker = 'RetMarker',
+  ForEndMarker = 'ForEndMarker'
 }
 
 export interface Marker {
@@ -234,6 +264,8 @@ export interface Marker {
 }
 
 export const RetMarker = { type: MarkerType.RetMarker }
+
+export const ForEndMarker = { type: MarkerType.ForEndMarker }
 
 export type Instruction =
   | SourceFile
@@ -243,6 +275,7 @@ export type Instruction =
   | ExpressionStatement
   | ReturnStatement
   | IfStatement
+  | ForStatement
   | Expression
   | VarDeclOp
   | AssignOp

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -265,10 +265,13 @@ export const PopS: PopSOp = { type: CommandType.PopSOp }
 
 export interface PopTillMOp extends Command {
   type: CommandType.PopTillMOp
-  marker: Marker
+  markers: Marker[]
 }
 
-export const PopTillM = (marker: Marker): PopTillMOp => ({ type: CommandType.PopTillMOp, marker })
+export const PopTillM = (...markers: Marker[]): PopTillMOp => ({
+  type: CommandType.PopTillMOp,
+  markers
+})
 
 export interface BuiltinOp extends Command {
   type: CommandType.BuiltinOp

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -9,6 +9,7 @@ export enum NodeType {
   IfStatement = 'IfStatement',
   ForStatement = 'ForStatement',
   ExpressionStatement = 'ExpressionStatement',
+  EmptyStatement = 'EmptyStatement',
   Assignment = 'Assignment',
   UnaryExpression = 'UnaryExpression',
   BinaryExpression = 'BinaryExpression',
@@ -21,7 +22,14 @@ type TopLevelDeclaration = Declaration | FunctionDeclaration
 
 type Declaration = VariableDeclaration
 
-type Statement = Declaration | ReturnStatement | IfStatement | ForStatement | Block
+type Statement =
+  | Declaration
+  | ReturnStatement
+  | IfStatement
+  | ForStatement
+  | Block
+  | SimpleStatement
+  | EmptyStatement
 
 type SimpleStatement = ExpressionStatement | Assignment | Declaration
 
@@ -103,6 +111,12 @@ export interface ExpressionStatement extends Node {
   expression: Expression
 }
 
+export interface EmptyStatement extends Node {
+  type: NodeType.EmptyStatement
+}
+
+export const EmptyStmt: EmptyStatement = { type: NodeType.EmptyStatement }
+
 export interface Assignment extends Node {
   type: NodeType.Assignment
   left: Expression[]
@@ -118,6 +132,8 @@ export interface Literal extends Node {
   type: NodeType.Literal
   value: any
 }
+
+export const True: Literal = { type: NodeType.Literal, value: true }
 
 export type UnaryOperator = '+' | '-'
 
@@ -276,6 +292,7 @@ export type Instruction =
   | ReturnStatement
   | IfStatement
   | ForStatement
+  | EmptyStatement
   | Expression
   | VarDeclOp
   | AssignOp

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -8,6 +8,8 @@ export enum NodeType {
   ReturnStatement = 'ReturnStatement',
   IfStatement = 'IfStatement',
   ForStatement = 'ForStatement',
+  BreakStatement = 'BreakStatement',
+  ContinueStatement = 'ContinueStatement',
   ExpressionStatement = 'ExpressionStatement',
   EmptyStatement = 'EmptyStatement',
   Assignment = 'Assignment',
@@ -27,6 +29,8 @@ type Statement =
   | ReturnStatement
   | IfStatement
   | ForStatement
+  | BreakStatement
+  | ContinueStatement
   | Block
   | SimpleStatement
   | EmptyStatement
@@ -99,6 +103,14 @@ export interface ForClause {
   init: SimpleStatement | null
   cond: Expression | null
   post: SimpleStatement | null
+}
+
+export interface BreakStatement extends Node {
+  type: NodeType.BreakStatement
+}
+
+export interface ContinueStatement extends Node {
+  type: NodeType.ContinueStatement
 }
 
 export interface Block extends Node {
@@ -292,6 +304,8 @@ export type Instruction =
   | ReturnStatement
   | IfStatement
   | ForStatement
+  | BreakStatement
+  | ContinueStatement
   | EmptyStatement
   | Expression
   | VarDeclOp

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -115,7 +115,7 @@ export interface ContinueStatement extends Node {
 
 export interface Block extends Node {
   type: NodeType.Block
-  statements: Statement[]
+  statements: (Statement | Marker)[]
 }
 
 export interface ExpressionStatement extends Node {
@@ -287,6 +287,8 @@ export interface ApplyBuiltinOp extends Command {
 
 export enum MarkerType {
   RetMarker = 'RetMarker',
+  ForStartMarker = 'ForStartMarker',
+  ForPostMarker = 'ForPostMarker',
   ForEndMarker = 'ForEndMarker'
 }
 
@@ -295,6 +297,10 @@ export interface Marker {
 }
 
 export const RetMarker = { type: MarkerType.RetMarker }
+
+export const ForStartMarker = { type: MarkerType.ForStartMarker }
+
+export const ForPostMarker = { type: MarkerType.ForPostMarker }
 
 export const ForEndMarker = { type: MarkerType.ForEndMarker }
 


### PR DESCRIPTION
# Description

This PR adds support for for-statements in the ECE. In the Go specification (https://go.dev/ref/spec#ForStmt), `ForStmt` takes 3 forms (`Condition`, `ForClause` and `RangeClause`), but this PR **only implements the `Condition` and `ForClause` forms**. `RangeClause` form for-statements primarily works with data structures like arrays, slices and strings, which we do not have support for currently.

In addition, this PR also implements `break` and `continue` statements **without labels**.

## Implementation Details

1. `Condition` form for-statements are semantically the same as while-loops, therefore the implementation closely mirrors `WhileStatement` in the Source ECE.
2. `Condition` form for-statements also serves as the base for the `ForClause` condition for-statements. As such the ECE transpiles `ForClause` form to `Condition` form in the following manner:

    ```go
    {
        init_statement
        for cond_expression {
            {
                ...for_block_statements
               ForPostMarker // IMPORTANT!
            }
            post_statement
        }
    }
    ```
3. To support `break` and `continue` statements, 3 new markers are introduced:
    - `ForStartMarker`: Mark the **start** of a for-statement (for `continue`)
    - `ForEndMarker`: Mark the **end** of a for-statement (for `break`)
    - `ForPostMarker`: Marker the **post statement** of a `ForClause` form for-statement (for `continue`)
        - We need this since calling `continue` statement in a `ForClause` form for-statement requires that the post statement to be evaluated (see below)

> [!NOTE]
> We need a `ForPostMarker` to handle cases like this:
> ```golang
> for a := 0; a < 10; a = a + 1 {
>     continue
> }
> ```
> Without the `ForPostMarker`, `continue` will pop till the`ForStartMarker` which does not update the value of `a`, resulting in a infinite loop
>
> **The position of the `ForPostMarker` needs to be in the position where `continue` restores the previous environment** (more details: https://github.com/shenyih0ng/go-slang/pull/9/commits/7a2a37d55610bac53d1493cdb3c1e8bb38fa0456)
 

## TODOs

- [x] Condition form `ForStatement`
- [x] Clause form `ForStatement`
- [x] `continue` statement
- [x] `break` statement
- [x] Fix edge cases (see list below)

```go
for c := 0; c < 3; c = c + 1 {
    c := 1
    continue
    break
}
```

