### PR TITLE
feat: parse time UID for AST nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "build": "yarn docs && yarn build:slang",
-    "build:go": "peggy src/go-slang/parser/*.pegjs",
+    "build:go": "peggy --cache --allowed-start-rules SourceFile src/go-slang/parser/*.pegjs",
     "build:slang": "yarn build:go && tsc --build --force",
     "eslint": "eslint --ext \".ts,.tsx\" src",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -4752,7 +4752,7 @@ function peg$parse(input, options) {
     let uid = 0; 
 
     function makeNode(node) {
-        return { ...node, uid: uid++ };
+        return { ...node, uid: uid++, loc: location() };
     }
 
     function buildLiteral(value) {

--- a/src/go-slang/parser/go.js
+++ b/src/go-slang/parser/go.js
@@ -19,24 +19,6 @@
         return parseInt(str.replaceAll("_", ""), base)
     }
 
-    function buildLiteral(value) {
-        return {
-            type: "Literal",
-            value: value
-        };
-    }
-    
-    function buildBinaryExpression(head, tail) {
-        return tail.reduce(function(result, element) {
-            return {
-                type: "BinaryExpression",
-                operator: element[1],
-                left: result,
-                right: element[3]
-            };
-        }, head);
-    }
-
 function peg$subclass(child, parent) {
   function C() { this.constructor = child; }
   C.prototype = parent.prototype;
@@ -364,14 +346,14 @@ function peg$parse(input, options) {
   var peg$e80 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
 
   var peg$f0 = function(topLevelDecls) {
-        return { type: "SourceFile", topLevelDecls }
+        return makeNode({ type: "SourceFile", topLevelDecls })
       };
   var peg$f1 = function(expression) { 
-        return { type: "ExpressionStatement", expression: expression } 
+        return makeNode({ type: "ExpressionStatement", expression: expression })
      };
   var peg$f2 = function(expression) { return expression };
   var peg$f3 = function() { 
-        return { type: "Identifier", name: text() } 
+        return makeNode({ type: "Identifier", name: text() })
       };
   var peg$f4 = function() { return buildLiteral(0); };
   var peg$f5 = function() {
@@ -387,47 +369,47 @@ function peg$parse(input, options) {
         return buildLiteral(buildInteger(digits, 16))
       };
   var peg$f9 = function(operator, argument) {
-        return {type: "UnaryExpression", operator: operator, argument: argument}
+        return makeNode({type: "UnaryExpression", operator, argument})
  	  };
   var peg$f10 = function(head, tail) { return buildBinaryExpression(head, tail); };
   var peg$f11 = function(head, tail) { return buildBinaryExpression(head, tail); };
   var peg$f12 = function(head, tail) { return buildBinaryExpression(head, tail); };
   var peg$f13 = function(callee, args) {
-        return { type: "CallExpression", callee, args: args ?? [] }
+        return makeNode({ type: "CallExpression", callee, args: args ?? [] })
       };
   var peg$f14 = function(declarations) {
-        return { type: "VariableDeclaration", ...declarations }
+        return makeNode({ type: "VariableDeclaration", ...declarations })
       };
   var peg$f15 = function(left, right) {
         return { left, right: right ? right[2] : [] }
       };
   var peg$f16 = function(left, right) {
-        return { type: "VariableDeclaration", left, right }
+        return makeNode({ type: "VariableDeclaration", left, right })
       };
   var peg$f17 = function(name, params, body) {
-        return { type: "FunctionDeclaration", name, params, body }
+        return makeNode({ type: "FunctionDeclaration", name, params, body })
       };
   var peg$f18 = function(params) { return params ?? [] };
   var peg$f19 = function(statements) {
-        return { type: "Block", statements }
+        return makeNode({ type: "Block", statements })
       };
   var peg$f20 = function(expression) {
-        return { type: "ReturnStatement", expression }
+        return makeNode({ type: "ReturnStatement", expression })
       };
   var peg$f21 = function(stmt, cond, cons, alt) {
-        return { type: "IfStatement", stmt, cond, cons, alt }
+        return makeNode({ type: "IfStatement", stmt, cond, cons, alt })
       };
   var peg$f22 = function(stmt) { return stmt };
   var peg$f23 = function(alt) { return alt };
-  var peg$f24 = function(form, block) { return { type: "ForStatement", form, block} };
+  var peg$f24 = function(form, block) { return makeNode({ type: "ForStatement", form, block}) };
   var peg$f25 = function(expression) { return { type: "ForCondition", expression } };
   var peg$f26 = function(init, cond, post) {
         return { type: "ForClause", init, cond, post }
       };
-  var peg$f27 = function() { return { type: "BreakStatement" } };
-  var peg$f28 = function() { return { type: "ContinueStatement" } };
+  var peg$f27 = function() { return makeNode({ type: "BreakStatement" }) };
+  var peg$f28 = function() { return makeNode({ type: "ContinueStatement" }) };
   var peg$f29 = function(left, right) {
-        return { type: "Assignment", left, right }
+        return makeNode({ type: "Assignment", left, right })
       };
   var peg$f30 = function(head, tail) { return buildList(head, tail, 3); };
   var peg$f31 = function(head, tail) { return buildList(head, tail, 3); };
@@ -437,6 +419,8 @@ function peg$parse(input, options) {
   var peg$maxFailPos = peg$currPos;
   var peg$maxFailExpected = options.peg$maxFailExpected || [];
   var peg$silentFails = options.peg$silentFails | 0;
+
+  var peg$resultsCache = {};
 
   var peg$result;
 
@@ -596,6 +580,15 @@ function peg$parse(input, options) {
   function peg$parseSourceFile() {
     var s0, s1, s2, s3;
 
+    var key = peg$currPos * 90 + 0;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
     s0 = peg$currPos;
     s1 = peg$parse_();
     s2 = [];
@@ -608,22 +601,44 @@ function peg$parse(input, options) {
     peg$savedPos = s0;
     s0 = peg$f0(s2);
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseTopLevelDeclaration() {
     var s0;
 
+    var key = peg$currPos * 90 + 1;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
     s0 = peg$parseVariableDeclaration();
     if (s0 === peg$FAILED) {
       s0 = peg$parseFunctionDeclaration();
     }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseStatement() {
     var s0;
+
+    var key = peg$currPos * 90 + 2;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$parseVariableDeclaration();
     if (s0 === peg$FAILED) {
@@ -648,11 +663,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSimpleStatement() {
     var s0;
+
+    var key = peg$currPos * 90 + 3;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$parseShortVariableDeclaration();
     if (s0 === peg$FAILED) {
@@ -662,11 +688,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseExpressionStatement() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 4;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseRelationalExpression();
@@ -679,11 +716,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parsePrimaryExpression() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 5;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$parseIdentifier();
     if (s0 === peg$FAILED) {
@@ -727,11 +775,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIdentifier() {
     var s0, s1, s2, s3, s4;
+
+    var key = peg$currPos * 90 + 6;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$currPos;
@@ -764,11 +823,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLetter() {
     var s0;
+
+    var key = peg$currPos * 90 + 7;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r0.test(s0)) {
@@ -778,11 +848,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e2); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIdentifierPart() {
     var s0;
+
+    var key = peg$currPos * 90 + 8;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r1.test(s0)) {
@@ -792,11 +873,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e3); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIntegerLit() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 9;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$parseHexInt();
@@ -815,11 +907,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e4); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseDecimalInt() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 10;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -864,11 +967,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e5); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseBinaryInt() {
     var s0, s1, s2, s3, s4;
+
+    var key = peg$currPos * 90 + 11;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -913,11 +1027,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e8); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseOctalInt() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 12;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -972,11 +1097,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e10); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseHexInt() {
     var s0, s1, s2, s3, s4;
+
+    var key = peg$currPos * 90 + 13;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -1021,11 +1157,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e12); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseDecimalDigit() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 14;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
@@ -1053,11 +1200,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseBinaryDigit() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 15;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
@@ -1085,11 +1243,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseOctalDigit() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 16;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
@@ -1117,11 +1286,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseHexDigit() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 17;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
@@ -1149,11 +1329,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseUnaryExpression() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 18;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$parseCallExpression();
     if (s0 === peg$FAILED) {
@@ -1177,11 +1368,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseUnaryOperator() {
     var s0;
+
+    var key = peg$currPos * 90 + 19;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r7.test(s0)) {
@@ -1191,11 +1393,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e19); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseMultiplicativeExpression() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key = peg$currPos * 90 + 20;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseUnaryExpression();
@@ -1245,11 +1458,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseMultiplicativeOperator() {
     var s0;
+
+    var key = peg$currPos * 90 + 21;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r8.test(s0)) {
@@ -1259,11 +1483,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e20); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseAdditiveExpression() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key = peg$currPos * 90 + 22;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseMultiplicativeExpression();
@@ -1313,11 +1548,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseAdditiveOperator() {
     var s0;
+
+    var key = peg$currPos * 90 + 23;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r9.test(s0)) {
@@ -1327,11 +1573,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e21); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseRelationalExpression() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key = peg$currPos * 90 + 24;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseAdditiveExpression();
@@ -1381,11 +1638,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseRelationalOperator() {
     var s0;
+
+    var key = peg$currPos * 90 + 25;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     if (input.substr(peg$currPos, 2) === peg$c7) {
       s0 = peg$c7;
@@ -1440,11 +1708,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseCallExpression() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 26;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parsePrimaryExpression();
@@ -1485,11 +1764,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseVariableDeclaration() {
     var s0, s1, s2, s3, s4;
+
+    var key = peg$currPos * 90 + 27;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseVAR_TOKEN();
@@ -1509,11 +1799,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseVarSpec() {
     var s0, s1, s2, s3, s4, s5, s6;
+
+    var key = peg$currPos * 90 + 28;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseIdentifierList();
@@ -1551,11 +1852,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseShortVariableDeclaration() {
     var s0, s1, s2, s3, s4, s5, s6;
+
+    var key = peg$currPos * 90 + 29;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseIdentifierList();
@@ -1588,11 +1900,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseFunctionDeclaration() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key = peg$currPos * 90 + 30;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -1632,11 +1955,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e30); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSignature() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 31;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
@@ -1672,11 +2006,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseBlock() {
     var s0, s1, s2, s3, s4, s5, s6;
+
+    var key = peg$currPos * 90 + 32;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$currPos;
@@ -1721,11 +2066,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e31); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseReturnStatement() {
     var s0, s1, s2, s3, s4;
+
+    var key = peg$currPos * 90 + 33;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseRETURN_TOKEN();
@@ -1745,11 +2101,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIfStatement() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key = peg$currPos * 90 + 34;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseIF_TOKEN();
@@ -1786,11 +2153,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIfSimpleStatement() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 35;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseSimpleStatement();
@@ -1814,11 +2192,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseElseBranch() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 36;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseELSE_TOKEN();
@@ -1840,11 +2229,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseForStatement() {
     var s0, s1, s2, s3, s4, s5, s6;
+
+    var key = peg$currPos * 90 + 37;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseFOR_TOKEN();
@@ -1869,22 +2269,44 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseForForm() {
     var s0;
 
+    var key = peg$currPos * 90 + 38;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
     s0 = peg$parseForClause();
     if (s0 === peg$FAILED) {
       s0 = peg$parseForCondition();
     }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
   function peg$parseForCondition() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 39;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseRelationalExpression();
@@ -1894,11 +2316,22 @@ function peg$parse(input, options) {
     }
     s0 = s1;
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseForClause() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    var key = peg$currPos * 90 + 40;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseSimpleStatement();
@@ -1944,11 +2377,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseBreakStatement() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 41;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseBREAK_TOKEN();
@@ -1961,11 +2405,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseContinueStatement() {
     var s0, s1, s2;
+
+    var key = peg$currPos * 90 + 42;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseCONTINUE_TOKEN();
@@ -1978,11 +2433,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5, s6;
+
+    var key = peg$currPos * 90 + 43;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseExpressionList();
@@ -2015,11 +2481,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIdentifierList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key = peg$currPos * 90 + 44;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseIdentifier();
@@ -2082,11 +2559,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseExpressionList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key = peg$currPos * 90 + 45;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parseRelationalExpression();
@@ -2149,11 +2637,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseComment() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 46;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = peg$parseMultiLineComment();
@@ -2166,11 +2665,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e36); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseMultiLineComment() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 47;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c19) {
@@ -2276,11 +2786,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseMultiLineCommentNoLineTerminator() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key = peg$currPos * 90 + 48;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c19) {
@@ -2432,11 +2953,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSingleLineComment() {
     var s0, s1, s2, s3, s4, s5;
+
+    var key = peg$currPos * 90 + 49;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c21) {
@@ -2518,11 +3050,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseEOS() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 50;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     s1 = peg$parse_();
@@ -2537,11 +3080,22 @@ function peg$parse(input, options) {
     s1 = [s1, s2, s3];
     s0 = s1;
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLineTerminator() {
     var s0;
+
+    var key = peg$currPos * 90 + 51;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r10.test(s0)) {
@@ -2551,11 +3105,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e41); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLineTerminatorSequence() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 52;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 10) {
@@ -2589,11 +3154,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e42); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseWhitespace() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 53;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     peg$silentFails++;
     s0 = input.charAt(peg$currPos);
@@ -2609,11 +3185,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e46); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parse_() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 54;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = [];
     s1 = peg$parseWhitespace();
@@ -2634,11 +3221,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parse__() {
     var s0, s1;
+
+    var key = peg$currPos * 90 + 55;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = [];
     s1 = peg$parseWhitespace();
@@ -2653,11 +3251,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseBREAK_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 56;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c24) {
@@ -2690,11 +3299,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseDEFAULT_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 57;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 7) === peg$c25) {
@@ -2727,11 +3347,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseFUNC_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 58;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c26) {
@@ -2764,11 +3395,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseINTERFACE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 59;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 9) === peg$c27) {
@@ -2801,11 +3443,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSELECT_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 60;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 6) === peg$c28) {
@@ -2838,11 +3491,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseCASE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 61;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c29) {
@@ -2875,11 +3539,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseDEFER_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 62;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c30) {
@@ -2912,11 +3587,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseGO_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 63;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c31) {
@@ -2949,11 +3635,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseMAP_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 64;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 3) === peg$c32) {
@@ -2986,11 +3683,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSTRUCT_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 65;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 6) === peg$c33) {
@@ -3023,11 +3731,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseCHAN_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 66;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c34) {
@@ -3060,11 +3779,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseELSE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 67;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c35) {
@@ -3097,11 +3827,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseGOTO_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 68;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c36) {
@@ -3134,11 +3875,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parsePACKAGE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 69;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 7) === peg$c37) {
@@ -3171,11 +3923,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseSWITCH_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 70;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 6) === peg$c38) {
@@ -3208,11 +3971,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseCONST_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 71;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c39) {
@@ -3245,11 +4019,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseFALLTHROUGH_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 72;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 11) === peg$c40) {
@@ -3282,11 +4067,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIF_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 73;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2) === peg$c41) {
@@ -3319,11 +4115,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseRANGE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 74;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 5) === peg$c42) {
@@ -3356,11 +4163,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseTYPE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 75;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 4) === peg$c43) {
@@ -3393,11 +4211,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseCONTINUE_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 76;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 8) === peg$c44) {
@@ -3430,11 +4259,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseFOR_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 77;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 3) === peg$c45) {
@@ -3467,11 +4307,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseIMPORT_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 78;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 6) === peg$c46) {
@@ -3504,11 +4355,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseRETURN_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 79;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 6) === peg$c47) {
@@ -3541,11 +4403,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseVAR_TOKEN() {
     var s0, s1, s2, s3;
+
+    var key = peg$currPos * 90 + 80;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 3) === peg$c48) {
@@ -3578,11 +4451,22 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseKeyword() {
     var s0;
+
+    var key = peg$currPos * 90 + 81;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = peg$parseBREAK_TOKEN();
     if (s0 === peg$FAILED) {
@@ -3658,11 +4542,22 @@ function peg$parse(input, options) {
       }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseUnicodeLetter() {
     var s0;
+
+    var key = peg$currPos * 90 + 82;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r13.test(s0)) {
@@ -3672,11 +4567,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e73); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLl() {
     var s0;
+
+    var key = peg$currPos * 90 + 83;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r14.test(s0)) {
@@ -3686,11 +4592,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e74); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLm() {
     var s0;
+
+    var key = peg$currPos * 90 + 84;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r15.test(s0)) {
@@ -3700,11 +4617,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e75); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLo() {
     var s0;
+
+    var key = peg$currPos * 90 + 85;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r16.test(s0)) {
@@ -3714,11 +4642,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e76); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLt() {
     var s0;
+
+    var key = peg$currPos * 90 + 86;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r17.test(s0)) {
@@ -3728,11 +4667,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e77); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseLu() {
     var s0;
+
+    var key = peg$currPos * 90 + 87;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r18.test(s0)) {
@@ -3742,11 +4692,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e78); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseNd() {
     var s0;
+
+    var key = peg$currPos * 90 + 88;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r19.test(s0)) {
@@ -3756,11 +4717,22 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e79); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
 
   function peg$parseNl() {
     var s0;
+
+    var key = peg$currPos * 90 + 89;
+    var cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
 
     s0 = input.charAt(peg$currPos);
     if (peg$r20.test(s0)) {
@@ -3770,8 +4742,33 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e80); }
     }
 
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
     return s0;
   }
+
+
+    // `uid` is a monotonically increasing unique identifier for AST nodes
+    let uid = 0; 
+
+    function makeNode(node) {
+        return { ...node, uid: uid++ };
+    }
+
+    function buildLiteral(value) {
+        return makeNode({ type: "Literal", value: value});
+    }
+    
+    function buildBinaryExpression(head, tail) {
+        return tail.reduce(function(result, element) {
+            return makeNode({
+                type: "BinaryExpression",
+                operator: element[1],
+                left: result,
+                right: element[3]
+            });
+        }, head);
+    }
 
   peg$result = peg$startRuleFunction();
 

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -11,29 +11,35 @@
         // note: we discard the "_" delimiters
         return parseInt(str.replaceAll("_", ""), base)
     }
+}}
+
+{
+    // `uid` is a monotonically increasing unique identifier for AST nodes
+    let uid = 0; 
+
+    function makeNode(node) {
+        return { ...node, uid: uid++ };
+    }
 
     function buildLiteral(value) {
-        return {
-            type: "Literal",
-            value: value
-        };
+        return makeNode({ type: "Literal", value: value});
     }
     
     function buildBinaryExpression(head, tail) {
         return tail.reduce(function(result, element) {
-            return {
+            return makeNode({
                 type: "BinaryExpression",
                 operator: element[1],
                 left: result,
                 right: element[3]
-            };
+            });
         }, head);
     }
-}}
+}
 
 SourceFile
     = _ topLevelDecls: TopLevelDeclaration* _ {
-        return { type: "SourceFile", topLevelDecls }
+        return makeNode({ type: "SourceFile", topLevelDecls })
       }
 
 TopLevelDeclaration
@@ -60,7 +66,7 @@ SimpleStatement
 
 ExpressionStatement
    = expression: Expression EOS { 
-        return { type: "ExpressionStatement", expression: expression } 
+        return makeNode({ type: "ExpressionStatement", expression: expression })
      }
 
 Expression
@@ -73,7 +79,7 @@ PrimaryExpression
 
 Identifier
     = !Keyword Letter IdentifierPart* { 
-        return { type: "Identifier", name: text() } 
+        return makeNode({ type: "Identifier", name: text() })
       }
 
 Letter
@@ -133,7 +139,7 @@ UnaryExpression
     = CallExpression 
     / PrimaryExpression
     / operator:UnaryOperator argument:UnaryExpression {
-        return {type: "UnaryExpression", operator: operator, argument: argument}
+        return makeNode({type: "UnaryExpression", operator, argument})
  	  }
  
 UnaryOperator
@@ -176,14 +182,14 @@ RelationalOperator
 
 CallExpression
     = callee:PrimaryExpression "(" args:ExpressionList? ")" EOS {
-        return { type: "CallExpression", callee, args: args ?? [] }
+        return makeNode({ type: "CallExpression", callee, args: args ?? [] })
       }
 
 /* Variable Declaration */
 
 VariableDeclaration
     = VAR_TOKEN __ declarations:VarSpec EOS {
-        return { type: "VariableDeclaration", ...declarations }
+        return makeNode({ type: "VariableDeclaration", ...declarations })
       }
 
 VarSpec
@@ -193,14 +199,14 @@ VarSpec
 
 ShortVariableDeclaration
     = left:IdentifierList _ ":=" _ right:ExpressionList EOS {
-        return { type: "VariableDeclaration", left, right }
+        return makeNode({ type: "VariableDeclaration", left, right })
       }
 
 /* Function Declaration */
 
 FunctionDeclaration "function declaration"
     = FUNC_TOKEN _ name:Identifier _ params:Signature _ body:Block EOS {
-        return { type: "FunctionDeclaration", name, params, body }
+        return makeNode({ type: "FunctionDeclaration", name, params, body })
       }
 
 Signature
@@ -210,21 +216,21 @@ Signature
 
 Block "block"
     = "{" _ statements:Statement* _ "}" EOS {
-        return { type: "Block", statements }
+        return makeNode({ type: "Block", statements })
       }
 
 /* Return Statement */
 
 ReturnStatement
     = RETURN_TOKEN _ expression:Expression EOS {
-        return { type: "ReturnStatement", expression }
+        return makeNode({ type: "ReturnStatement", expression })
       }
 
 /* If Statement */
 
 IfStatement
     = IF_TOKEN _ stmt:IfSimpleStatement? _ cond:Expression _ cons:Block _ alt:ElseBranch? EOS {
-        return { type: "IfStatement", stmt, cond, cons, alt }
+        return makeNode({ type: "IfStatement", stmt, cond, cons, alt })
       }
 
 IfSimpleStatement
@@ -236,7 +242,7 @@ ElseBranch
 /* For Statement */
 
 ForStatement
-    = FOR_TOKEN __ form:ForForm? __ block:Block EOS { return { type: "ForStatement", form, block} }
+    = FOR_TOKEN __ form:ForForm? __ block:Block EOS { return makeNode({ type: "ForStatement", form, block}) }
       
 ForForm
 	= ForClause
@@ -253,18 +259,18 @@ ForClause
 /* Break Statement */
 
 BreakStatement
-    = BREAK_TOKEN EOS { return { type: "BreakStatement" } }
+    = BREAK_TOKEN EOS { return makeNode({ type: "BreakStatement" }) }
 
 /* Continue Statement */
 
 ContinueStatement
-    = CONTINUE_TOKEN EOS { return { type: "ContinueStatement" } }
+    = CONTINUE_TOKEN EOS { return makeNode({ type: "ContinueStatement" }) }
 
 /* Assignment */
 
 Assignment
     = left:ExpressionList _ "=" _ right:ExpressionList EOS {
-        return { type: "Assignment", left, right }
+        return makeNode({ type: "Assignment", left, right })
       }
 
 IdentifierList

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -18,7 +18,7 @@
     let uid = 0; 
 
     function makeNode(node) {
-        return { ...node, uid: uid++ };
+        return { ...node, uid: uid++, loc: location() };
     }
 
     function buildLiteral(value) {

--- a/src/go-slang/types.ts
+++ b/src/go-slang/types.ts
@@ -39,8 +39,21 @@ type SimpleStatement = ExpressionStatement | Assignment | Declaration
 
 type Expression = Identifier | Literal | UnaryExpression | BinaryExpression | CallExpression
 
+interface Position {
+  line: number
+  column: number
+  offset: number
+}
+interface NodeLocation {
+  start: Position
+  end: Position
+  offset: number
+}
+
 export interface Node {
   type: NodeType
+  uid?: number
+  loc?: NodeLocation
 }
 
 export interface SourceFile extends Node {


### PR DESCRIPTION
# Description

This PR adds UID and location (this was a low-hanging fruit for better error messages) to AST nodes at parse time. A example of what a AST node looks like now:

```diff
{
  type: 'SourceFile',
+ uid: 3,
+ loc: { source: undefined, start: { offset: 0, line: 1, column: 1 }, end: { offset: 15, line: 2, column: 2 } }
  topLevelDecls: [
    {
      type: 'FunctionDeclaration',
      name: {
        type: 'Identifier',
        name: 'main',
+       uid: 0,
+       loc: { source: undefined, start: { offset: 5, line: 1, column: 6 }, end: { offset: 9, line: 1, column: 10 } }
      },
      params: [],
      body: {...}
+     uid: 2,
+     loc: { source: undefined, start: { offset: 0, line: 1, column: 1 }, end: {offset: 15, line: 2, column: 2 } }
    }
  ],
}
```
Some useful invariants to take note of for the generated UIDs:

1. `SourceFile` will always have the highest UID
2. UID at `SourceFile` tells us how many nodes we have for the entire program