### PR TITLE
feat: enhance parser with concurrency constructs

### DIFF
--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -201,11 +201,11 @@ CommClause
         return makeNode({ type: "CommClause", pred, statements })
       }
 CommCase
-    = CASE_TOKEN _ statement:(ReceiveStatement / SendStatement) EOS { return statement }
+    = CASE_TOKEN _ statement:(SendStatement / ReceiveStatement) EOS { return statement }
     / DEFAULT_TOKEN { return [] }
 
 ReceiveStatement
-    = left:( ExpressionList __ "=" / IdentifierList __ ":=" ) __ right:ReceiveExpression EOS {
+    = left:( ExpressionList __ "=" / IdentifierList __ ":=" )? __ right:ReceiveExpression EOS {
         return makeNode({ type: "ReceiveStatement", left, right })
       }
 

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -193,20 +193,20 @@ CallExpression
 
 SelectStatement "select statement"
     = SELECT_TOKEN _ "{" _ cases:CommClause* _ "}" EOS {
-        return { type: "SelectStatement", cases }
-    }
+        return makeNode({ type: "SelectStatement", cases })
+      }
 
 CommClause
     = pred:CommCase __ ":" _ statements:Statement* EOS {
-        return { type: "CommClause", pred, statements }
+        return makeNode({ type: "CommClause", pred, statements })
       }
 CommCase
-    = CASE_TOKEN _ statement:(ReceiveStatement / SendStatement) EOS { return statement}
+    = CASE_TOKEN _ statement:(ReceiveStatement / SendStatement) EOS { return statement }
     / DEFAULT_TOKEN { return [] }
 
 ReceiveStatement
-    = left:( ExpressionList __ "=" / IdentifierList __ ":=" ) __ right:ReceiveExpression EOS {
-        return { type: "ReceiveStatement", left, right }
+    = left:( ExpressionList __ "=" / IdentifierList __ ":=" )* __ right:ReceiveExpression EOS {
+        return makeNode({ type: "ReceiveStatement", left, right })
       }
 
 ReceiveExpression
@@ -216,14 +216,14 @@ ReceiveExpression
 
 GoStatement
     = GO_TOKEN __ call:Expression EOS {
-        return { type: "GoStatement", call }
+        return makeNode({ type: "GoStatement", call })
       }
 
 /* Send Declaration */
 
 SendStatement
     = channel:Channel _ "<-" _ value:Expression EOS {
-        return { type: "SendStatement", channel, value }
+        return makeNode({ type: "SendStatement", channel, value })
       }
 
 Channel

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -47,7 +47,9 @@ TopLevelDeclaration
     / FunctionDeclaration
 
 Statement
-    = Declaration
+    = SelectStatement
+    / GoStatement
+    / Declaration
     / SimpleStatement
     / ReturnStatement
     / IfStatement
@@ -60,7 +62,8 @@ Declaration
     = VariableDeclaration
 
 SimpleStatement
-    = ShortVariableDeclaration
+    = SendStatement
+    / ShortVariableDeclaration
     / Assignment
     / ExpressionStatement
 
@@ -145,6 +148,7 @@ UnaryExpression
 UnaryOperator
     = "+" 
     / "-"
+    / "<-"
 
 MultiplicativeExpression
     = head: UnaryExpression
@@ -184,6 +188,46 @@ CallExpression
     = callee:PrimaryExpression "(" args:ExpressionList? ")" EOS {
         return makeNode({ type: "CallExpression", callee, args: args ?? [] })
       }
+
+/* Select Statement */
+
+SelectStatement "select statement"
+    = SELECT_TOKEN _ "{" _ cases:CommClause* _ "}" EOS {
+        return { type: "SelectStatement", cases }
+    }
+
+CommClause
+    = pred:CommCase __ ":" _ statements:Statement* EOS {
+        return { type: "CommClause", pred, statements }
+      }
+CommCase
+    = CASE_TOKEN _ statement:(ReceiveStatement / SendStatement) EOS { return statement}
+    / DEFAULT_TOKEN { return [] }
+
+ReceiveStatement
+    = left:( ExpressionList __ "=" / IdentifierList __ ":=" ) __ right:ReceiveExpression EOS {
+        return { type: "ReceiveStatement", left, right }
+      }
+
+ReceiveExpression
+    = Expression
+
+/* Go Statement */
+
+GoStatement
+    = GO_TOKEN __ call:Expression EOS {
+        return { type: "GoStatement", call }
+      }
+
+/* Send Declaration */
+
+SendStatement
+    = channel:Channel _ "<-" _ value:Expression EOS {
+        return { type: "SendStatement", channel, value }
+      }
+
+Channel
+    = Expression
 
 /* Variable Declaration */
 

--- a/src/go-slang/parser/go.pegjs
+++ b/src/go-slang/parser/go.pegjs
@@ -205,7 +205,7 @@ CommCase
     / DEFAULT_TOKEN { return [] }
 
 ReceiveStatement
-    = left:( ExpressionList __ "=" / IdentifierList __ ":=" )* __ right:ReceiveExpression EOS {
+    = left:( ExpressionList __ "=" / IdentifierList __ ":=" ) __ right:ReceiveExpression EOS {
         return makeNode({ type: "ReceiveStatement", left, right })
       }
 


### PR DESCRIPTION
**Summary**

This PR introduces new parsing capabilities to the Go parser, focusing on concurrency constructs and enhancing the language's support for channels and goroutines. Key changes include:

- Added `SelectStatement`, `GoStatement`, and `SendStatement` to support Go's concurrency patterns.
- Included the `<-` unary operator for channel operations.

**Testing**

Usable Code Block
```golang


var a, b = 3,2

func hello() {
	a <- 3
}

func main() {
    hello()
    a = b
    b
    select {
    case a <- 3:
    	a = 4
    case b = <-c:
    	b = 3
      default:
      	a = 3
    }
}

```


