### PR TITLE
feat: unbuffered channel

### DIFF
--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -77,6 +77,21 @@ export class Stack<T> implements IStack<T> {
     return this.storage[this.size() - 1]
   }
 
+  /**
+   * Returns the top n items in the stack.
+   *
+   * @param n amount of items to peek from the top of the stack
+   * @returns an array of the top n items in the stack
+   *          the first item in the array is the top of the stack
+   */
+  public peekN(n: number): T[] | undefined {
+    if (this.isEmpty()) {
+      return undefined
+    }
+
+    return this.storage.slice(-n).reverse()
+  }
+
   public size(): number {
     return this.storage.length
   }

--- a/src/go-slang/lib/channel.ts
+++ b/src/go-slang/lib/channel.ts
@@ -15,6 +15,131 @@ class Channel {
   protected setSlotValue(slotIdx: number, value: number): void { this.memory.setFloat64(this.getSlotAddr(slotIdx), value) }
 }
 
+export class UnbufferedChannel extends Channel {
+  static RECV_ID_OFFSET = 1
+  static SEND_ID_OFFSET = 3
+  static SYNCED_OFFSET = 7
+
+  static NULL_ID = -1
+
+  constructor(memory: DataView) { super(memory) } // prettier-ignore
+
+  public send(routineId: number, value: any): boolean {
+    const isSender = this.sendId === routineId
+    if (isSender) {
+      if (this.synced) {
+        // there is a receiver that has already taken the value
+        // that the current routine was trying to send previously
+        // therefore, the current routine can continue
+
+        // reset the channel state
+        this.reset()
+        return true
+      } else {
+        // the value hasn't been taken by a receiver
+        // so the routine needs to continue waiting
+        return false
+      }
+    }
+
+    if (this.hasSender() || this.synced) {
+      // if there is another sender or another sync is happening, the current routine
+      // cannot send the value and needs to wait
+      return false
+    }
+
+    // there is no sender and no sync happening
+    // the current routine can try to send the value
+
+    this.setSlotValue(0, value) // set the value to be sent
+    this.sendId = routineId // claim the channel as the sender
+
+    if (this.hasReceiver()) {
+      // if there is a receiver waiting, the current routine can proceed to start
+      // the sync process
+      this.synced = true
+      return true
+    } else {
+      // no receiver waiting, the current routine needs to wait
+      // we hand the responsibility of syncing to the receiver
+      return false
+    }
+  }
+
+  public recv(routineId: number): number | null {
+    const isReciever = this.recvId === routineId
+    if (isReciever) {
+      if (this.synced) {
+        // there is a value to be recieved by the current routine
+        // that was trying to recieve previously
+        // therefore, the current routine can continue
+
+        // extract the value from the channel and reset the channel state
+        const value = this.getSlotValue(0)
+        this.reset()
+        return value
+      } else {
+        // there is no value to be recieved so the routine needs to continue waiting
+        return null
+      }
+    }
+
+    if (this.hasReceiver() || this.synced) {
+      // if there is another reciever or another sync is happening, the current routine
+      // cannot try to recieve a value and needs to wait
+      return null
+    }
+
+    // there is no reciever and no sync happening
+    // the current routine can try to recieve a value
+
+    if (this.hasSender()) {
+      // if there is a sender waiting, the current routine can proceed to start
+      // the recieve the value and start the sync process
+      this.synced = true
+      return this.getSlotValue(0)
+    } else {
+      // no sender waiting, the current routine needs to wait
+      // we hand the responsibility of syncing to the sender
+      return null
+    }
+  }
+
+  private hasSender(): boolean { return this.sendId !== UnbufferedChannel.NULL_ID } // prettier-ignore
+
+  private hasReceiver(): boolean { return this.recvId !== UnbufferedChannel.NULL_ID } // prettier-ignore
+
+  private get recvId(): number {
+    return this.memory.getInt16(UnbufferedChannel.RECV_ID_OFFSET)
+  }
+
+  private set recvId(newRecvId: number) {
+    this.memory.setInt16(UnbufferedChannel.RECV_ID_OFFSET, newRecvId)
+  }
+
+  private get sendId(): number {
+    return this.memory.getInt16(UnbufferedChannel.SEND_ID_OFFSET)
+  }
+
+  private set sendId(newSendId: number) {
+    this.memory.setInt16(UnbufferedChannel.SEND_ID_OFFSET, newSendId)
+  }
+
+  private get synced(): boolean {
+    return this.memory.getUint8(UnbufferedChannel.SYNCED_OFFSET) === 1
+  }
+
+  private set synced(hasSynced: boolean) {
+    this.memory.setUint8(UnbufferedChannel.SYNCED_OFFSET, hasSynced ? 1 : 0)
+  }
+
+  private reset(): void {
+    this.sendId = UnbufferedChannel.NULL_ID
+    this.recvId = UnbufferedChannel.NULL_ID
+    this.synced = false
+  }
+}
+
 export class BufferedChannel extends Channel {
   static READ_IDX_OFFSET = 1
   static WRITE_IDX_OFFSET = 2

--- a/src/go-slang/lib/heap/tags.ts
+++ b/src/go-slang/lib/heap/tags.ts
@@ -13,5 +13,6 @@ export enum PointerTag {
   ClosureOp,
   EnvOp,
   PopSOp,
-  BufferedChannel
+  BufferedChannel,
+  UnbufferedChannel
 }


### PR DESCRIPTION
# Description

This PR implements unbuffered channel support for the Go ECE. For an unbuffered channel, the sender blocks until the receiver has received the value (https://go.dev/doc/effective_go#channels).

## Implementation Details

1. An unbuffered channel in the Go ECE is represented using 2 words (`2*8 = 16` bytes) including the tagged pointer
     - We store the ids of the sender and receiver goroutines in the tagged pointer, each occupying 2 bytes, hence we are assuming an upper bound of `2^16` goroutines in total
     - The one word (8 bytes) that follows the tagged pointer will be used as a slot for senders to send to and receivers to receive from 
     - We also use 1 byte in the tagged pointer to track if there is a sync process happening
         - _More details of what the sync process is can be found in the [`UnbufferedChannel`](https://github.com/shenyih0ng/go-slang/blob/44a36d7f3562b68789ae8db6de431dfb911a331e/src/go-slang/lib/channel.ts#L18) implementation (i've left a bunch of comments to explain the behaviour)_

2. Unlike the actual implementation of channels in go (https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub) that relies on mutexes, I opted to model channels as its own independent construct. This means that the unbuffered channel itself is responsible for signalling/blocking goroutines.
