### PR TITLE
feat: yield scheduler when blocked

### DIFF
--- a/src/go-slang/error.ts
+++ b/src/go-slang/error.ts
@@ -88,3 +88,9 @@ export class GoExprMustBeFunctionError extends RuntimeSourceError {
     return `expression in go statement must be function call, not ${this.expr}`
   }
 }
+
+export class DeadLockError extends RuntimeSourceError {
+  public explain() {
+    return 'all goroutines are asleep - deadlock!'
+  }
+}

--- a/src/go-slang/lib/utils.ts
+++ b/src/go-slang/lib/utils.ts
@@ -22,24 +22,35 @@ export function isAny<T1, T2>(query: T1, values: T2[]): boolean {
   return query ? values.some(v => v === query) : false
 }
 
-export class Result<E extends SourceError> {
+export class Result<T, E extends SourceError> {
+  private value: T | undefined
+
   public isSuccess: boolean
   public isFailure: boolean
   public error: E | undefined
 
-  private constructor(isSuccess: boolean, error?: E) {
+  private constructor(isSuccess: boolean, error?: E, value?: T) {
     this.isSuccess = isSuccess
     this.isFailure = !isSuccess
     this.error = error
+    this.value = value
+
     Object.freeze(this)
   }
 
-  public static ok<E extends SourceError>(): Result<E> {
-    return new Result(true)
+  public unwrap(): T {
+    if (this.isFailure) {
+      throw new Error('called `unwrap` on a failed result')
+    }
+    return this.value as T
   }
 
-  public static fail<E extends SourceError>(error: E): Result<E> {
-    return new Result(false, error)
+  public static ok<T, E extends SourceError>(value?: T): Result<T, E> {
+    return new Result<T, E>(true, undefined, value)
+  }
+
+  public static fail<T, E extends SourceError>(error: E): Result<T, E> {
+    return new Result<T, E>(false, error)
   }
 }
 

--- a/src/go-slang/lib/utils.ts
+++ b/src/go-slang/lib/utils.ts
@@ -61,3 +61,23 @@ export class Counter {
   constructor (start: number = 0) { this.count = start }
   public next(): number { return this.count++ }
 }
+
+export function benchmark(label: string) {
+  function _benchmark(
+    _target: any,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor
+  ): PropertyDescriptor {
+    const originalMethod = descriptor.value
+
+    descriptor.value = function (...args: any[]) {
+      const start = performance.now()
+      const result = originalMethod.apply(this, args)
+      console.log(`[${label}] exec time: ${(performance.now() - start).toFixed(2)}ms`)
+      return result
+    }
+
+    return descriptor
+  }
+  return _benchmark
+}

--- a/src/go-slang/scheduler.ts
+++ b/src/go-slang/scheduler.ts
@@ -1,6 +1,7 @@
 import { Context as SlangContext } from '..'
 import { GoRoutine, GoRoutineState } from './goroutine'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
+import { benchmark } from './lib/utils'
 
 type TimeQuanta = number
 
@@ -24,6 +25,7 @@ export class Scheduler {
     this.routines.push([routine, Scheduler.randTimeQuanta()])
   }
 
+  @benchmark('Scheduler.run')
   public run(): void {
     while (this.routines.length) {
       const [routine, timeQuanta] = this.routines.shift() as [GoRoutine, TimeQuanta]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "target": "es2016",
+    "experimentalDecorators": true,
     "lib": [
       "es2021.string",
       "es2018",


### PR DESCRIPTION
# Description

This PR implements the optimisation by yielding scheduler time to other goroutines if the current one is blocked. Previously goroutines take up the entire time quantum even if it was blocked, preventing other idle goroutines from executing.

Additionally, I have also added an naive deadlock detection mechanism, exiting from the program if all goroutines are blocked. However because of how syncing process of unbuffered channels work, we cannot simply exit the moment the scheduler sees that all goroutines are blocked. This is because during the syncing process of unbuffered channels, both the sender and receiver will be blocked, but progress is being made. Therefore, to detect deadlocks, we are checking for `N` consecutive cycles where all `N` goroutines are blocked before exiting and erroring.

_I have also added a `@benchmark` decorator for testing our scheduler_