### PR TITLE
fix: preceding simple statement in `IfStmt` should have its own block

### DIFF
--- a/src/go-slang/goroutine.ts
+++ b/src/go-slang/goroutine.ts
@@ -184,7 +184,14 @@ const Interpreter: {
 
   IfStatement: ({ stmt, cond, cons, alt }: IfStatement, { C, H }) => {
     const branchOp: BranchOp = { type: CommandType.BranchOp, cons, alt }
-    stmt ? C.pushR(...H.allocM([stmt, cond, branchOp])) : C.pushR(...H.allocM([cond, branchOp]))
+    stmt
+      ? C.push(
+          H.alloc({
+            type: NodeType.Block,
+            statements: [stmt, { type: NodeType.IfStatement, cond, cons, alt }]
+          })
+        )
+      : C.pushR(...H.allocM([cond, branchOp]))
   },
 
   ForStatement: (inst: ForStatement, { C, H }) => {


### PR DESCRIPTION
# Description

Right now the ECE fails the following test case:

```go
func main() {
    var i = 26
    
    if i := 25; i % 3 == 0 && i % 5 == 0 {
        println("FizzBuzz")
    } else if i % 3 == 0 {
        println("Fizz")
    } else if i % 5 == 0 {
        println(i) // 25 
        println("Buzz") // Buzz
    }
    
    println(i) // 26
}
```

This is because the declaration `i:=25` incorrectly reassigns the `i` in the scope of `main`. The fix is to surround the if statement with a block if there is a preceding statement