### PR TITLE
fix: for statement init declarations

### DIFF
--- a/src/go-slang/goroutine.ts
+++ b/src/go-slang/goroutine.ts
@@ -209,13 +209,21 @@ const Interpreter: {
       )
     } else if (form.type === ForFormType.ForClause) {
       const { init, cond, post } = form
+      const initDeclIds = init && init.type === NodeType.VariableDeclaration ? init.left : []
       const forCond = {
         type: NodeType.ForStatement,
         form: { type: ForFormType.ForCondition, expression: cond ?? True },
         block: {
           type: NodeType.Block,
           statements: [
-            { ...forBlock, statements: forBlock.statements.concat(ForPostMarker()) },
+            {
+              type: NodeType.Block,
+              statements: [
+                // eqv to: id = id (copy of init declarations with the current values)
+                { type: NodeType.VariableDeclaration, left: initDeclIds, right: initDeclIds },
+                ...forBlock.statements.concat(ForPostMarker())
+              ]
+            },
             post ?? EmptyStmt
           ]
         }


### PR DESCRIPTION
# Description

The Go ECE desugars the `ForClause` form for statement into a `ForCond` for statement:

```diff
{
  init
  FOR_START_MARKER
  for cond {
    {
      ...stmts
      FOR_POST_MARKER
    }
    post 
  }
  FOR_END_MARKER
}
```

However in the case where the `init` statement contains an declaration statement, the scope of the variable declared will be in the most outer block. This becomes an issue for closures, more specifically function literals, as the value of declarations will not be preserved as the loop advances.

For example:

```go
func main() {
    wg := new(sync.WaitGroup)
    wg.Add(5)

    for i := 1; i <= 5; i++ {
        go func() {
            println(i)
            wg.Done()
        }()
    }

    wg.Wait()
}
```

We expect that there will be no repeated values of `i` in `stdout`, however because the value of `i` is not preserved in each block scope, there is a chance that we will get repeated values.

The (naive) fix would then be inject extra variable declarations to preserve the declarations found in the `init` statement:

```diff
{
  init
  FOR_START_MARKER
  for cond {
    {
+     copy of init declarations (e.g. var id1, id2 = id1, id2)
      ...stmts
      FOR_POST_MARKER
    }
    post 
  }
  FOR_END_MARKER
}
```